### PR TITLE
Add agent docs, voice guide, and a social cross-posting skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+This is the Jekyll source for [hardkoded.com](https://www.hardkoded.com), Darío Kondratiuk's personal blog (hosted as `kblok.github.io` on GitHub Pages). It's a fork/customization of the "Beautiful Jekyll" theme. There is no application code, build pipeline, or test suite — just Jekyll content, layouts, and static assets.
+
+## Commands
+
+Serve the site locally (uses the `github-pages` gem, pinned to match GitHub Pages' actual environment):
+
+```
+bundle install
+bundle exec jekyll serve
+```
+
+Site is served at `http://localhost:4000`.
+
+Alternatively, via Docker (uses an old, pinned toolchain — `Dockerfile` installs Jekyll 3.1.6 and specific gem versions):
+
+```
+docker build -t kblok.github.io .
+docker run -p 4000:4000 kblok.github.io
+```
+
+There is no linter, formatter, or test suite in this repo.
+
+## Content architecture
+
+- **`_posts/`** — main blog posts (Markdown), filename pattern `YYYY-MM-DD-slug.md`. Front matter uses `title`, `tags` (space-separated string, e.g. `tags: puppeteer-sharp csharp`), and `permalink` (posts use custom permalinks like `/blog/...` rather than the site-wide `/:year-:month-:day-:title/` default). Layout defaults to `post` via `_config.yml` scoping rules, so it usually doesn't need to be declared per-file.
+- **`_tils/`** — a separate Jekyll collection ("Today I Learned" short posts), rendered on `til.html`. Front matter here explicitly sets `layout: post`, `tags` as a comma-separated string (different convention from `_posts`), and a `/til/...` permalink.
+- **`tag/*.md`** — one stub page per tag (`layout: tag_index`), used as the target for tag-index URLs. `_data/tags.yml` lists known tag slugs/names. Actual tag→post indexing is generated automatically by `_plugins/_tag_gen.rb` (a Jekyll `Generator` that builds a `TagIndex` page per tag found in `site.tags`, using `_layouts/tag_index.html`) — you don't need to hand-maintain per-tag post lists.
+- **`goto/*.md`** — short-link redirect pages (`layout: redirected`, `redirect_to: <url>`), rendered via `_layouts/redirect.html` (meta-refresh + JS redirect). Used for stable outbound links (e.g. Slack invites) that might change destination later without changing the short URL.
+- **`ui-testing-with-puppeteer/`** — a large flat set of standalone reference `.md` notes (not a Jekyll collection with an index); mostly source material/snippets related to the "UI Testing with Puppeteer" book.
+- **`_layouts/`** and **`_includes/`** — standard Jekyll templating. `base.html` is the root layout; `default.html`/`page.html`/`post.html`/`minimal.html` build on it. Analytics/social/comments snippets live in `_includes/` (`google_analytics.html`, `gtm_head.html`/`gtm_body.html`, `disqus.html`, `social-share.html`) and are pulled in via `_config.yml` values (`google_analytics`, `gtm`, `disqus`) rather than hardcoded per page.
+- **`_config.yml`** — site-wide settings: nav bar links, colors, social links (`_data/SocialNetworks.yml` backs the `social-network-links` keys), Disqus/GA IDs, permalink scheme, and the `defaults` block that sets `layout: post` for everything under `_posts` and `layout: page` for everything else.
+
+## Conventions to follow when adding content
+
+- New blog posts: add to `_posts/` with a `YYYY-MM-DD-slug.md` filename, `title`, `tags` (space-separated), and an explicit `permalink: /blog/<slug>`.
+- New TILs: add to `_tils/` with `YYYY-MM-DD-slug.md`, and front matter matching the existing pattern (`layout: post`, comma-separated `tags`, `permalink: /til/<slug>`).
+- Introducing a brand-new tag: add an entry to `_data/tags.yml` and create the matching `tag/<slug>.md` stub (copy an existing one and change `tag`/`title`/`permalink`) — the tag index generator does the rest.
+- Adding a redirect/short link: add a file under `goto/` following `goto/pptr-slack.md`'s front matter shape.

--- a/voice.md
+++ b/voice.md
@@ -1,0 +1,71 @@
+# Voice guide
+
+Notes on how Darío writes on hardkoded.com, built from reading ~18 posts across years and post types (technical deep-dives, personal essays, milestone announcements, book reviews, monthly reports, TILs). Use this when drafting a new post so it sounds like him, not like generic AI-assistant prose.
+
+## The sign-off
+
+Almost every post (except TILs) ends with:
+
+> Don't stop coding!
+
+Sometimes with one extra line right before it, matching the post's occasion:
+- "Happy automation!  \nDon't stop coding!"
+- "I hope you can get more of my posts soon :)  \nDon't stop coding!"
+
+Always end a full post with this line unless there's a strong reason not to.
+
+## Post shapes (pick the one that matches what you're writing)
+
+**1. Technical deep-dive / tutorial** (e.g. the async void post, interprocess communication, Azure Functions)
+- Opens with a short, plain-language hook — often a "Let's see if..." or a one-line problem statement, not a formal intro.
+  - "Let's see if we can get Puppeteer-Sharp running into an Azure Function."
+  - "Let me tell you a story about async voids, SynchronizationContext, and async programming."
+- Narrates in first-person-plural, present tense, as a live walkthrough: "Let's create...", "Now, let's go to...", "We are going to..."
+- Poses the real question as an `##` header, then answers it directly underneath: "How is it possible that a try-catch block can't catch an Exception?", "Is async void the problem?"
+- Code comments carry personality, not just explanation: `// If microsoft docs tells me to call this method I will.` / `// This is how a .NET developer leaves an app open in Node.JS`
+- Uses a comic dramatic pause via stacked lines before a punchline reveal:
+  ```
+  Can I connect a .NET app there?
+  .
+  .
+  .
+  .
+  No, you can't.
+  ```
+- Closes with a `# Final Words` (capitalization varies) section that steps back and states the one takeaway, then the sign-off.
+
+**2. Personal essay / opinion** (e.g. "my language is the best", "how to start an OSS project", "hello world")
+- Anecdote or personal claim first, general lesson second — never leads with the abstract point.
+- Pulls the post's key line out into its own blockquote for emphasis, sometimes literally repeating a sentence from the paragraph above:
+  > "If you want to finish an OSS project, you will need a roadmap"
+- Talks directly to the reader and pre-empts their reaction: "I know what you might be thinking now, and it's true." / "You might say..."
+- Self-deprecating asides: "Don't judge me.", "Pretty lame right?", "if you don't notice that I write like a caveman..."
+- Ends on an encouraging, community-first note, then the sign-off.
+
+**3. Milestone / announcement** (e.g. MVP award, book release, Playwright Sharp joining Microsoft, monthly reports)
+- Opens with genuine excitement, stated plainly, not hyped up: "I'm super excited to share...", "It is my pleasure to announce that today..."
+- Anticipates the skeptical reader question as its own header, answers it head-on: "Wait, did you give the project away?", "But, why?", "Are you leaving the project?"
+- Always redirects credit outward — names specific people and links them, thanks them by name. Personal wins are framed as community wins ("It's not my project. It's OURS.").
+- Raw numbers are presented unembellished as bullet lists (stars, downloads, reputation) without spin — the framing/humility comes in the surrounding prose, not the numbers.
+- Closes with a "final words" beat that's modest about the achievement, then the sign-off.
+
+**4. TIL** (`_tils/`)
+- One or two sentences of context (often just "why I needed this"), then the command/snippet. No sign-off, no sections, no fluff.
+  > "If I'm going to Google every time I need to kill a process locking a port let's at least get to my site"
+
+## Recurring devices, usable in any post type
+
+- **Rhetorical question → direct answer**, often as the header itself, then a blunt one-line answer right after: "Isn't `async void` the root of all evil? ... But that weird question helped me to understand that I wasn't getting what my problem was."
+- **"Let's..." as a transition**, used constantly to move to the next step or topic, not just in tutorials.
+- **Bold** for the single sentence that is the actual point of a paragraph/section — used like a highlighter, not for keywords.
+- **GIFs** (usually Giphy) dropped in at emotional beats — reveal, frustration, celebration — doing comic timing that words alone would spell out. Use sparingly and only where a beat needs a laugh, not as decoration.
+- Occasional emoji, always at the very end of a sentence, for a wink/self-aware tone: 😉 😜 ⭐️. Never more than one or two per post.
+- Light self-aware jabs at his own English/writing: "I know I write like a caveman", informal contractions and run-on asides are fine — don't over-polish into "correct" textbook English. The voice is a non-native English speaker writing casually and confidently, not performing perfect prose.
+- Community/gratitude is not an afterthought — if a post is about an achievement, expect at least one paragraph naming and linking the people who helped, by name.
+
+## What NOT to do
+
+- Don't open with a throat-clearing intro paragraph ("In this post, we will explore..."). Get to the hook in the first sentence.
+- Don't write a generic corporate-blog closing ("In conclusion, ..."). Use "Final Words" / "Wrapping up" framed as a personal takeaway, then "Don't stop coding!"
+- Don't smooth out every sentence into perfectly polished English — some informality and directness is part of the voice.
+- Don't bury the human context. Even in a pure code tutorial, there's usually a one-line reason *why* ("I really want to implement it on Playwright-Sharp. So let's see how far we are from getting this done.").


### PR DESCRIPTION
Started as agent-facing reference docs, grew into a small toolkit for this repo.

**CLAUDE.md** covers how the Jekyll site is put together — `_posts` vs `_tils` front-matter conventions, how the tag-index generator works, the `goto/` redirect pages, and how to serve it locally.

**voice.md** distills how Dario actually writes, pulled from ~18 real posts across different styles (technical deep-dives, personal essays, milestone announcements, TILs) — things like the "Don't stop coding!" sign-off, the rhetorical-question-as-header pattern, and giving credit outward on milestone posts. Meant to keep future drafted posts sounding like him instead of generic blog-assistant prose.

**`.claude/skills/promote-post`** is a new skill for cross-posting. A GitHub Action that auto-posts to Twitter/X and LinkedIn isn't really viable — X requires a paid API tier to post, and LinkedIn's personal-profile API needs manual app review plus a token that expires every 60 days, neither of which works from a stateless CI job. Instead, this skill converts a full post or TIL into paste-ready plain text for LinkedIn's "Write an article" and an X Premium long-form post — no API keys, no OAuth, no auto-posting. It just hands over clean copy and Dario publishes it himself.

Also includes a small wording tweak to the Puppeteer-Sharp 2023 recap post that was already staged locally.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>