### PR TITLE
Add "Back to Sharing in a Post-Blog Era" post

### DIFF
--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -1,3 +1,5 @@
 - slug: bots
   name: Bots
+- slug: ai
+  name: AI
 

--- a/_posts/2026-07-03-back-to-sharing-in-a-post-blog-era.md
+++ b/_posts/2026-07-03-back-to-sharing-in-a-post-blog-era.md
@@ -1,0 +1,28 @@
+---
+title: Back to Sharing in a Post-Blog Era
+tags: general ai
+permalink: /blog/back-to-sharing-in-a-post-blog-era
+---
+
+The last time I shared something on this blog was in 2023. Almost three years!! No, I didn't retire (yet). I was just working. A lot.
+
+Let's be honest: blogs are dead. I don't read blogs anymore either. All the good content today lives in X posts, LinkedIn articles, and, well, in a chat with Claude.
+
+So coming back to writing here is hard. You lose the exercise, and once you lose it, sitting down to write again feels like starting from zero. But here I am, back in this post-blog era. And, not by coincidence, in the middle of an AI era too.
+
+I use AI pretty much all the time now, and I'm not the only one. A lot of folks are doing the same thing, and sharing it.
+
+> I want to share things that actually help the community, not just chase engagement.
+
+That's what I've been trying to do for the last 8 years, and the format changing doesn't change that.
+
+A few things already in motion:
+
+- Puppeteer-Sharp is now fully automated with AI. You'll hear more about that soon.
+- A fully native Playwright-Sharp version, coded end-to-end with AI, is coming.
+- Soon I'll start sharing some of the AI skills I use every day.
+
+As a first example: if you're reading this post on X or LinkedIn, it got there through one of those skills, [promote-post](https://github.com/kblok/kblok.github.io/tree/master/.claude/skills/promote-post).
+
+I hope you can get more of my posts soon :)  
+Don't stop coding!

--- a/tag/ai.md
+++ b/tag/ai.md
@@ -1,0 +1,6 @@
+---
+layout: tag_index
+tag: ai
+title: AI
+permalink: /tag/ai/
+---


### PR DESCRIPTION
First post since the 2023 Puppeteer-Sharp recap. Short one on coming back to writing after a long stretch heads-down at work, and why now: everything's shifted to AI, and there's stuff worth sharing that isn't just chasing likes on X/LinkedIn.

Sets up a couple of teasers (fully-automated Puppeteer-Sharp, a native Playwright-Sharp coded with AI, and upcoming posts on the AI skills used day to day) without pinning down hard timelines, since those are still in motion.

Also adds a new `ai` tag (`_data/tags.yml` + `tag/ai.md`) since there's more AI-flavored content coming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)